### PR TITLE
Backport things changed for inclusion in guile

### DIFF
--- a/srfi-171.html
+++ b/srfi-171.html
@@ -49,7 +49,7 @@
 
 <p>Transducers are oblivious to what kind of process they are used in,
   and are composable without building intermediate collections.  This
-  means we can create a transducer that squares all even numbers:
+  means we can create a transducer that squares all odd numbers:
   <code>(compose (tfilter odd?) (tmap (lambda (x) (* x x))))</code>
   and reuse it with lists, vectors, or in just about any context where
   data flows in one direction.  We could use it as a processing step
@@ -383,7 +383,7 @@
 
 
 <h3 id="tdrop-while-pred"><code>(tdrop-while</code> <em>pred?</em><code>)</code></h3>
-<p>Returns a transducer that discards the the first values for which
+<p>Returns a transducer that discards the first values for which
   <em>pred?</em> returns true.</p>
 
 <p>Stateful.</p>
@@ -536,12 +536,12 @@
 
 
 <h3 id="port-reduce"><code>(port-reduce</code> <em> f identity reader port</em><code>)</code></h3>
-<p> The port version of <code>list-reducer</code>.  It reduces over <em>port</em> using
+<p> The port version of <code>list-reduce</code>.  It reduces over <em>port</em> using
     <em>reader</em> until <em>reader</em> returns the EOF object.</p>
 
 
 <h3 id="generator-reduce"><code>(generator-reduce</code> <em> f identity gen</em><code>)</code></h3>
-<p> The port version of <code>list-reducer</code>.  It reduces over <em>gen</em> until it returns
+<p> The generator version of <code>list-reduce</code>.  It reduces over <em>gen</em> until it returns
      the EOF object</p>
 
 

--- a/srfi/171-impl.scm
+++ b/srfi/171-impl.scm
@@ -66,7 +66,7 @@
     (() 0)
     ((result) result)
     ((result input)
-     (+ 1  result))))
+     (+ 1 result))))
 
 
 ;; These two take a predicate and returns reducing functions that behave
@@ -354,7 +354,9 @@
                         (reducer result (vector->list collect 0 i)))))
                (set! i 0)
                ;; now finally, pass it downstreams
-               (reducer result)))
+               (if (reduced? result)
+                   (reducer (unreduce result))
+                   (reducer result))))
             ((result input)
              (vector-set! collect i input)
              (set! i (+ i 1))
@@ -366,8 +368,6 @@
                    (reducer result next-input)))))))))
 
 
-;; I am not sure about the correctness of this. It seems to work.
-;; we could maybe make it faster?
 (define (tpartition f)
   (lambda (reducer)
     (let* ((prev nothing)
@@ -380,7 +380,9 @@
                     result
                     (reducer result (reverse! collect)))))
            (set! collect '())
-           (reducer result)))
+           (if (reduced? result)
+               (reducer (unreduce result))
+               (reducer result))))
         ((result input)
          (let ((fout (f input)))
            (cond

--- a/srfi/171-impl.scm
+++ b/srfi/171-impl.scm
@@ -286,7 +286,7 @@
 
 
 ;; Flattens everything and passes each value through the reducer
-;; (list-transduce tflatten conj (list 1 2 (list 3 4 '(5 6) 7 8))) => (1 2 3 4 5 6 7 8)
+;; (list-transduce tflatten rcons (list 1 2 (list 3 4 '(5 6) 7 8))) => (1 2 3 4 5 6 7 8)
 (define tflatten
   (lambda (reducer)
     (case-lambda
@@ -336,7 +336,6 @@
 
 ;; Partitions the input into lists of N items. If the input stops it flushes whatever
 ;; it has collected, which may be shorter than n.
-;; I am not sure about the correctness about this. It seems to work.
 (define (tsegment n)
   (if (not (and (integer? n) (positive? n)))
       (error "argument to tsegment must be a positive integer")

--- a/srfi/srfi-171.scm
+++ b/srfi/srfi-171.scm
@@ -26,7 +26,7 @@
                   list-transduce
                   vector-transduce
                   string-transduce
-                  bytevector-u8transduce
+                  bytevector-u8-transduce
                   port-transduce
                   generator-transduce
                   


### PR DESCRIPTION
Hi!

SRFI-171 was included in guile some time during the 3.0 release. There was some eyeballing, and fingers were pointed towards two code comments about my own certainty of the behaviour of the code. To be clear, I was never able to force erroneous behaviour of the code when used with a xxx-transduce form, but these changes done now makes damn sure things are done correctly. 

The test suite (which is anemic - I should really make a more complete one) passes in both guile and gauche. I don't know what happened in the chibi cond-expand, but that is not my code and I didn't have time to look into why I couldn't make it run.

This pull request also fixes some typos.

Best regards
Linus Björnstam